### PR TITLE
Display revision:

### DIFF
--- a/Eru/src/main/java/com/eru/entities/Display.java
+++ b/Eru/src/main/java/com/eru/entities/Display.java
@@ -1,26 +1,102 @@
 package com.eru.entities;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import javafx.beans.property.*;
 
 import javax.persistence.*;
 
-@Data
 @Entity
-@NoArgsConstructor
-@AllArgsConstructor
 @Table(name = "display", schema = "public")
 public class Display {
+
+    private final LongProperty id;
+    private StringProperty name;
+    private StringProperty groupName;
+    private BooleanProperty initialDisplay;
+    private ObjectProperty<StageType> stageType;
+
+    public Display() {
+        this.id = new SimpleLongProperty(this, "display_id");
+        this.name = new SimpleStringProperty(this, "name", "");
+        this.groupName = new SimpleStringProperty(this, "name", "");
+        this.initialDisplay = new SimpleBooleanProperty(this, "initial_display", false);
+        this.stageType = new SimpleObjectProperty<>(this, "stageType", StageType.REPLACE);
+    }
 
     @Id
     @Column(name = "display_id")
     @GeneratedValue(strategy = GenerationType.AUTO)
-    private long id;
+    public long getId() {
+        return id.get();
+    }
+
+    public LongProperty idProperty() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id.set(id);
+    }
+
     @Column(name = "name")
-    private String name;
+    public String getName() {
+        return name.get();
+    }
+
+    public StringProperty nameProperty() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name.set(name);
+    }
+
     @Column(name = "group_name")
-    private String groupName;
-    @Column(name = "deleted")
-    private boolean deleted;
+    public String getGroupName() {
+        return groupName.get();
+    }
+
+    public StringProperty groupNameProperty() {
+        return groupName;
+    }
+
+    public void setGroupName(String groupName) {
+        this.groupName.set(groupName);
+    }
+
+    @Column(name = "initial_display")
+    public boolean isInitialDisplay() {
+        return initialDisplay.get();
+    }
+
+    public BooleanProperty initialDisplayProperty() {
+        return initialDisplay;
+    }
+
+    public void setInitialDisplay(boolean initialDisplay) {
+        this.initialDisplay.set(initialDisplay);
+    }
+
+    @Transient
+    public StageType getStageType() {
+        return stageType.get();
+    }
+
+    public ObjectProperty<StageType> stageTypeProperty() {
+        return stageType;
+    }
+
+    public void setStageType(StageType stageType) {
+        this.stageType.set(stageType);
+    }
+
+    @Column(name = "stage_type")
+    public String getStageTypeName() {
+        return getStageType() == null ? "" : getStageType().name();
+    }
+
+    public void setStageTypeName(String name) {
+        setStageType(name == null || name.isEmpty() ? StageType.REPLACE : StageType.valueOf(name));
+    }
+
+    public enum StageType {REPLACE, NEW}
 }

--- a/Eru/src/main/java/com/eru/gui/component/DisplayTable.java
+++ b/Eru/src/main/java/com/eru/gui/component/DisplayTable.java
@@ -2,14 +2,17 @@ package com.eru.gui.component;
 
 import com.eru.entities.Display;
 import com.eru.entities.TreeElementsGroup;
+import com.eru.gui.ApplicationContextHolder;
 import com.eru.gui.model.ProjectModel;
 import com.eru.scenebuilder.SceneBuilderStarter;
-import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
 import javafx.collections.transformation.FilteredList;
 import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.*;
+import javafx.scene.control.cell.CheckBoxTableCell;
+import javafx.scene.control.cell.ChoiceBoxTableCell;
 import javafx.scene.control.cell.TextFieldTableCell;
 import javafx.scene.layout.GridPane;
 import lombok.extern.slf4j.Slf4j;
@@ -20,30 +23,49 @@ import java.util.Optional;
 @Slf4j
 public class DisplayTable extends EruTableView<Display> {
 
-    public DisplayTable(SceneBuilderStarter sceneBuilderStarter) {
+    public DisplayTable() {
         TableColumn<Display, String> groupColumn = new TableColumn<>("Group");
-        TableColumn<Display, String> userNameColumn = new TableColumn<>("Name");
+        TableColumn<Display, String> nameColumn = new TableColumn<>("Name");
+        TableColumn<Display, Display.StageType> stageTypeColumn = new TableColumn<>("Stage type");
+        TableColumn<Display, Boolean> initialDisplayColumn = new TableColumn<>("Initial");
 
-        groupColumn.setCellValueFactory(param -> new SimpleStringProperty(param.getValue().getGroupName()));
+        groupColumn.setCellValueFactory(param -> param.getValue().groupNameProperty());
         groupColumn.setCellFactory(TextFieldTableCell.forTableColumn());
-        groupColumn.prefWidthProperty().bind(widthProperty().multiply(0.50));
+        groupColumn.prefWidthProperty().bind(widthProperty().multiply(0.25));
 
-        userNameColumn.setCellValueFactory(param -> new SimpleStringProperty(param.getValue().getName()));
-        userNameColumn.setCellFactory(TextFieldTableCell.forTableColumn());
-        userNameColumn.prefWidthProperty().bind(widthProperty().multiply(0.50));
+        nameColumn.setCellValueFactory(param -> param.getValue().nameProperty());
+        nameColumn.setCellFactory(TextFieldTableCell.forTableColumn());
+        nameColumn.prefWidthProperty().bind(widthProperty().multiply(0.25));
+
+        stageTypeColumn.prefWidthProperty().bind(widthProperty().multiply(0.25));
+        stageTypeColumn.setCellValueFactory(param -> param.getValue().stageTypeProperty());
+        stageTypeColumn.setCellFactory(ChoiceBoxTableCell.forTableColumn(
+                FXCollections.observableArrayList(Display.StageType.values())
+        ));
+
+        initialDisplayColumn.setCellValueFactory(param -> param.getValue().initialDisplayProperty());
+        initialDisplayColumn.setCellFactory(CheckBoxTableCell.forTableColumn(initialDisplayColumn));
+        initialDisplayColumn.prefWidthProperty().bind(widthProperty().multiply(0.25));
 
         getColumns().addAll(
                 groupColumn,
-                userNameColumn);
+                nameColumn,
+                stageTypeColumn,
+                initialDisplayColumn
+                );
 
-        setEditable(false);
+        setEditable(true);
         getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
+        addGraphicEditorMenuItem();
+    }
 
-        setOnMousePressed(event -> {
-            if (event.isPrimaryButtonDown() && event.getClickCount() == 2) {
-                sceneBuilderStarter.startSceneBuilder(getSelectionModel().getSelectedItem());
-            }
-        });
+    private void addGraphicEditorMenuItem() {
+        final MenuItem displayEditor = new MenuItem("Edit graphic");
+        final SceneBuilderStarter sceneBuilderStarter = ApplicationContextHolder.getApplicationContext().
+                getBean(SceneBuilderStarter.class);
+        displayEditor.setOnAction(event ->
+                sceneBuilderStarter.startSceneBuilder(getSelectionModel().getSelectedItem()));
+        contextMenu.getItems().add(displayEditor);
     }
 
     @Override

--- a/Eru/src/main/java/com/eru/gui/component/EruTableView.java
+++ b/Eru/src/main/java/com/eru/gui/component/EruTableView.java
@@ -20,6 +20,7 @@ public abstract class EruTableView<Item> extends TableView<Item> {
     protected StringProperty textToFilter;
     protected ObservableList<Item> items;
     protected FilteredList<Item> filteredItems;
+    protected ContextMenu contextMenu;
 
     EruTableView() {
         AnchorPane.setTopAnchor(this, 0.0);
@@ -27,18 +28,22 @@ public abstract class EruTableView<Item> extends TableView<Item> {
         AnchorPane.setRightAnchor(this, 0.0);
         AnchorPane.setLeftAnchor(this, 0.0);
 
-        ContextMenu contextMenu = new ContextMenu();
+        this.contextMenu = new ContextMenu();
+        addEventHandler(MouseEvent.MOUSE_CLICKED, t -> {
+            if (t.getButton() == MouseButton.SECONDARY) {
+                contextMenu.show(this, t.getScreenX(), t.getScreenY());
+            }
+        });
+        addDefaultMenuItems();
+    }
+
+    private void addDefaultMenuItems(){
         MenuItem addMenuItem = new MenuItem("Add");
         addMenuItem.setOnAction(event -> addNewItem());
         MenuItem deleteMenuItem = new MenuItem("Delete");
         deleteMenuItem.setOnAction(event -> deleteSelectedItems());
         contextMenu.getItems().add(addMenuItem);
         contextMenu.getItems().add(deleteMenuItem);
-        addEventHandler(MouseEvent.MOUSE_CLICKED, t -> {
-            if (t.getButton() == MouseButton.SECONDARY) {
-                contextMenu.show(this, t.getScreenX(), t.getScreenY());
-            }
-        });
     }
 
     private void deleteSelectedItems() {

--- a/Eru/src/main/java/com/eru/gui/controller/CenterPaneController.java
+++ b/Eru/src/main/java/com/eru/gui/controller/CenterPaneController.java
@@ -33,7 +33,7 @@ public class CenterPaneController implements SceneBuilderStarter {
         ConnectionsTableView connectionsTableView = new ConnectionsTableView();
         DevicesTableView devicesTableView = new DevicesTableView();
         TagsTableView tagsTableView = new TagsTableView();
-        DisplayTable displayTableView = new DisplayTable(this);
+        DisplayTable displayTableView = new DisplayTable();
         centerPane.getChildren().addAll(usersTableView, connectionsTableView, devicesTableView, tagsTableView,
                 displayTableView);
         centerPane.getChildren().forEach(this::adjustToAnchorPaneAndHide);

--- a/Eru/src/main/java/com/eru/gui/controller/MenuBarController.java
+++ b/Eru/src/main/java/com/eru/gui/controller/MenuBarController.java
@@ -63,7 +63,7 @@ public class MenuBarController {
             log.info("Launching tags.");
             tagLinksManager.linkToConnections();
             log.info("Launching displays.");
-            final Display mainDisplay = projectModel.getDisplays().stream().filter(display -> display.getName().equals("Main")).findAny().get();
+            final Display mainDisplay = projectModel.getDisplays().stream().filter(Display::isInitialDisplay).findAny().get();
             final File sceneFxmlFile = sceneFxmlManager.createSceneFxmlFile(mainDisplay);
             final URL fxmlFileUrl = sceneFxmlFile.toURI().toURL();
             final Parent mainNode = FXMLLoader.load(fxmlFileUrl);

--- a/Eru/src/main/java/com/eru/util/TagLinksManager.java
+++ b/Eru/src/main/java/com/eru/util/TagLinksManager.java
@@ -121,10 +121,12 @@ public class TagLinksManager {
                         .forEach(tag -> tag.valueProperty().addListener((observable, oldValue, newValue) -> extractedDisplay.setCurrentText(newValue)));
             } else if (extractedControl instanceof EruGauge) {
                 EruGauge extractedGauge = (EruGauge) extractedControl;
+                if (extractedGauge.getCurrentValueTagID().isEmpty()) return;
                 projectModel.getTags()
                         .stream()
                         .filter(tag -> tag.getId() == Integer.valueOf(extractedGauge.getCurrentValueTagID()))
                         .forEach(tag -> tag.valueProperty().addListener((observable, oldValue, newValue) -> extractedGauge.setCurrentValue(Double.parseDouble(newValue))));
+                if (extractedGauge.getCurrentTitleTagID().isEmpty()) return;
                 projectModel.getTags()
                         .stream()
                         .filter(tag -> tag.getId() == Integer.valueOf(extractedGauge.getCurrentTitleTagID()))

--- a/Eru/src/test/groovy/com/eru/scenebuilder/SceneFxmlManagerTest.groovy
+++ b/Eru/src/test/groovy/com/eru/scenebuilder/SceneFxmlManagerTest.groovy
@@ -21,7 +21,13 @@ class SceneFxmlManagerTest extends Specification {
         applicationDirectory.getValue() >> localPath
         eruPreferences.getApplicationDirectory() >> applicationDirectory
         when:
-        def sceneFxmlFile = sceneFxmlManager.createSceneFxmlFile(new Display(1L, 'Test scene', 'group', false))
+        def display = new Display();
+        display.setId(1L);
+        display.setName("Test Scene")
+        display.setGroupName("group")
+        display.setInitialDisplay(false)
+        display.setStageType(Display.StageType.REPLACE)
+        def sceneFxmlFile = sceneFxmlManager.createSceneFxmlFile(display)
         then:
         sceneFxmlFile.name == 'test-scene.fxml'
         getFileContent(sceneFxmlFile) == NEW_FXML_FILE_CONTENT


### PR DESCRIPTION
These are the changes: 
- Display fields are observable to be linked to the TableView.
- Display table updated: Double click to edit rows (Fixed #53), context menu to launch editor (Scene Builder), and more columns.
- Display have a new property called initialDisplay: To know where to start when launching SCADA.

**NOTE**
The database rows for Display Table changed. Be aware if you have using this table.